### PR TITLE
Added requirement to Django 1.7.7 to resolve compilation errors

### DIFF
--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -2,3 +2,4 @@ dj-database-url==0.2.2
 gunicorn==18.0
 static==1.0.2
 otree-core==0.2.278
+django==1.7.7


### PR DESCRIPTION
Running oTree-launcher the first time results in compilation errors due to missing django.db.models.related package which was removed with the release of Django 1.8 (see https://code.djangoproject.com/ticket/21414).

Compilation errors could also be resolved by not using the models.related package, but this is unnecessary as Django 1.8 is not yet officially supported by oTree.