### PR TITLE
Fix script tag for global custom.js include

### DIFF
--- a/_templates/global/Base.html
+++ b/_templates/global/Base.html
@@ -13,5 +13,5 @@
     <script src="//code.highcharts.com/highcharts-3d.js"></script>
     <script src="//code.highcharts.com/modules/exporting.js"></script>
     <!--Custom scripts-->
-    <script type="text/javascript" href="{% static 'global/custom.js' %}" />
+    <script type="text/javascript" src="{% static 'global/custom.js' %}" />
 {% endblock %}


### PR DESCRIPTION
I am not a web programmer, so I may well be missing something here... but I noticed that `/static/global/custom.js` was not being included from `Base.html`, and a quick look [here](http://www.w3schools.com/tags/tag_script.asp) suggests that this should be a `src` rather than an `href`.

Hope this helps!