### PR TITLE
Fixed the failing Travis-CI build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,9 @@ before_script:
 script:
   - otree test
 env:
-  - DATABASE_URL=postgres://postgres@localhost/travis_ci_test
+  global:
+    - DATABASE_URL=postgres://postgres@localhost/travis_ci_test
+    
+    # do not load /etc/boto.cfg with Python 3 incompatible plugin
+    # https://github.com/travis-ci/travis-ci/issues/5246#issuecomment-166460882
+    - BOTO_CONFIG=/doesnotexist


### PR DESCRIPTION
Fixing Issue #57 .

As discussed in Issue [#5246](https://github.com/travis-ci/travis-ci/issues/5246) of Travis-CI, the boto package in the venv is not fully Python 3 ready and will fail the build. Defaulting the config to something useless stops the failing plugin from starting.