### PR TITLE
Feature: add basic Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+# syntax=docker/dockerfile:1
+FROM python:3
+ENV PYTHONUNBUFFERED=1
+WORKDIR /oTree
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.7"
+services:
+  db:
+    image: postgres
+    volumes:
+      - ./data/db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_DB=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+  web:
+    build: .
+    command: otree prodserver 8888
+    volumes:
+      - .:/oTree
+    ports:
+      - "8888:8888"
+    depends_on:
+      - db
+


### PR DESCRIPTION
Good morning,

I am using oTree for research for my master thesis and I have missed the ability to have it set up containerized. Primarily because it would be easier to set up a isolated environment on a machine, and fast deployment to non-Heroku servers.

Please review PR and make necessary changes!